### PR TITLE
Add color palette to editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ android-build
 *.apk
 *.apk.idsig
 android_deployment_settings.json
+.DS_Store

--- a/Editor/Editor.cpp
+++ b/Editor/Editor.cpp
@@ -2,6 +2,6 @@
 _LogToFile_("Editor.log");
 //
 
-#include "Camps1te\Editor\Main.h"
+#include <Camps1te/Editor/Main.h>
 
 int main(int argc, char* argv[]) { return Camps1te::Editor::Main(argc, argv); }

--- a/Editor/include/Camps1te/Editor/App.h
+++ b/Editor/include/Camps1te/Editor/App.h
@@ -11,6 +11,8 @@
 #include <QHeaderView>
 #include <QIcon>
 #include <QMainWindow>
+#include <QMenu>
+#include <QMenuBar>
 #include <QMessageBox>
 #include <QSortFilterProxyModel>
 #include <QStandardItem>
@@ -131,6 +133,29 @@ namespace Camps1te::Editor {
 
             auto* mapView = new UI::MapGraphicsView();
             mapView->setScene(scene);
+
+            // MenuBar
+            QMenuBar* menuBar = mainWindow.menuBar();
+
+            QMenu*   fileMenu   = menuBar->addMenu("File");
+            QAction* exitAction = fileMenu->addAction("Exit");
+            exitAction->setShortcut(QKeySequence("Ctrl+Q"));
+            QObject::connect(exitAction, &QAction::triggered, [&]() { mainWindow.close(); });
+
+            // Windows menu
+            QMenu*   windowsMenu     = menuBar->addMenu("Windows");
+            QAction* mapEditorAction = windowsMenu->addAction("Color Palette");
+            mapEditorAction->setShortcut(QKeySequence("Ctrl+P"));
+            QObject::connect(mapEditorAction, &QAction::triggered, [&]() {
+                colorPaletteDock->show();
+            });
+
+            QMenu*   helpMenu    = menuBar->addMenu("Help");
+            QAction* aboutAction = helpMenu->addAction("About");
+            aboutAction->setShortcut(QKeySequence("F1"));
+            QObject::connect(aboutAction, &QAction::triggered, [&]() {
+                QMessageBox::information(&mainWindow, "About", "CAMPS1TE experimental");
+            });
 
             mainWindow.setCentralWidget(mapView);
             mainWindow.addDockWidget(Qt::RightDockWidgetArea, colorPaletteDock);

--- a/Editor/include/Camps1te/Editor/MiscExamples/ChooserAndList.h
+++ b/Editor/include/Camps1te/Editor/MiscExamples/ChooserAndList.h
@@ -10,7 +10,7 @@
 
 namespace Camps1te::Editor::MiscExamples::ChooserAndList {
 
-    void Run(int argc, char* argv[]) {
+    int Run(int argc, char* argv[]) {
         QApplication app(argc, argv);
 
         // Create main window and layout
@@ -58,6 +58,6 @@ namespace Camps1te::Editor::MiscExamples::ChooserAndList {
 
         window.show();
 
-        app.exec();
+        return app.exec();
     }
 }

--- a/Editor/include/string_format.h
+++ b/Editor/include/string_format.h
@@ -1,0 +1,6 @@
+#pragma once
+
+// Until I figure out why Clang 15 isn't working with std::format, I'll use fmt::format
+
+#include <fmt/format.h>
+#define string_format(...) fmt::format(__VA_ARGS__)

--- a/Editor/xmake.lua
+++ b/Editor/xmake.lua
@@ -1,8 +1,8 @@
-add_requires("nlohmann_json", "string_format", "_Log_", "spdlog")
+add_requires("nlohmann_json", "fmt", "_Log_", "spdlog")
 
 target("Camps1te Editor")
     set_kind("binary")
     add_files("*.cpp", "../Resources/Editor.qrc")
     add_includedirs("include")
     add_qt()
-    add_packages("nlohmann_json", "string_format", "_Log_", "spdlog")
+    add_packages("nlohmann_json", "fmt", "_Log_", "spdlog")

--- a/xmake/qt.lua
+++ b/xmake/qt.lua
@@ -18,13 +18,10 @@ function add_qt()
         add_includedirs(path.join(qt_include, "QtCore"))
         add_includedirs(path.join(qt_include, "QtGui"))
         add_includedirs(path.join(qt_include, "QtWidgets"))
-        add_includedirs(path.join(qt_include, "QtQuick"))
-        add_includedirs(path.join(qt_include, "QtQml"))
-        add_includedirs(path.join(qt_include, "QtQuickWidgets"))
 
         -- link
         add_linkdirs(qt_lib)
-        add_links("Qt6Core", "Qt6Gui", "Qt6Widgets", "Qt6Quick", "Qt6Qml", "Qt6QuickWidgets")
+        add_links("Qt6Core", "Qt6Gui", "Qt6Widgets")
 
         -- compiler flag
         add_cxflags("/Zc:__cplusplus")
@@ -40,21 +37,15 @@ function add_qt()
         add_includedirs(path.join(qt_lib, "QtCore.framework", "Headers"))
         add_includedirs(path.join(qt_lib, "QtGui.framework", "Headers"))
         add_includedirs(path.join(qt_lib, "QtWidgets.framework", "Headers"))
-        add_includedirs(path.join(qt_lib, "QtQuick.framework", "Headers"))
-        add_includedirs(path.join(qt_lib, "QtQml.framework", "Headers"))
-        add_includedirs(path.join(qt_lib, "QtQuickWidgets.framework", "Headers"))
 
         -- link
         add_linkdirs(path.join(qt_lib, "QtCore.framework"))
         add_linkdirs(path.join(qt_lib, "QtGui.framework"))
         add_linkdirs(path.join(qt_lib, "QtWidgets.framework"))
-        add_linkdirs(path.join(qt_lib, "QtQuick.framework"))
-        add_linkdirs(path.join(qt_lib, "QtQml.framework"))
-        add_linkdirs(path.join(qt_lib, "QtQuickWidgets.framework"))
 
         -- frameworks
-        add_ldflags("-F" .. qt_lib_dir)
-        add_frameworks("QtCore", "QtGui", "QtWidgets", "QtQuick", "QtQml", "QtQuickWidgets")
+        add_ldflags("-F" .. qt_lib)
+        add_frameworks("QtCore", "QtGui", "QtWidgets")
 
     elseif is_host("linux") then
         -- TODO


### PR DESCRIPTION
- Dockable color palette with red, green, blue
- Clicking on any map cell pops up message containing both x/y coordinate and the color selected
- Added Windows > Color Palette to show the Color Palette (if you close the dock)